### PR TITLE
[Detail] 상품 상세페이지 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,126 @@
-# applemarket_app
+# 🍎 Apple Market App
 
-A new Flutter project.
+> **Flutter로 구현한 중고거래 마켓플레이스 앱**
 
-## Getting Started
+<div align="center">
+  <img src="https://img.shields.io/badge/Flutter-02569B?style=for-the-badge&logo=flutter&logoColor=white" />
+  <img src="https://img.shields.io/badge/Dart-0175C2?style=for-the-badge&logo=dart&logoColor=white" />
+  <img src="https://img.shields.io/badge/Riverpod-0175C2?style=for-the-badge&logo=flutter&logoColor=white" />
+</div>
 
-This project is a starting point for a Flutter application.
+---
 
-A few resources to get you started if this is your first Flutter project:
+## 📱 앱 소개
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+**Apple Market**은 당근마켓 스타일의 중고거래 앱입니다.
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+### ✨ 주요 기능
+
+| 기능 | 설명 |
+|------|------|
+| 🏠 **메인 페이지** | 판매 중인 상품들을 카드 형태로 한눈에 확인 |
+| 🔍 **상품 상세** | 상품 이미지, 설명, 가격, 판매자 정보를 자세히 조회 |
+| 👤 **판매자 정보** | 판매자 프로필과 매너온도 시스템 |
+| 🔔 **알림 기능** | 클릭하면 스낵바 메시지 도출 |
+
+---
+
+## 🏗️ 프로젝트 아키텍처
+
+### 📁 프로젝트 구조
+```
+lib/
+├── 📄 main.dart              # 앱 진입점
+├── 📂 screens/               # 화면 UI 파일들
+│   ├── main_page.dart        # 메인 홈 화면
+│   └── detail_page.dart      # 상품 상세 화면
+├── 📂 models/                # 데이터 모델
+│   └── product.dart          # 상품 모델 클래스
+├── 📂 viewmodels/            # 비즈니스 로직
+│   └── home_viewmodel.dart   # 홈 화면 상태 관리
+├── 📂 data/                  # 데이터 레이어
+│   └── products_data.dart    # 샘플 상품 데이터
+└── 📂 assets/                # 이미지 리소스
+    ├── sample0.jpg
+    ├── sample1.png
+    └── ... (sample10.png까지)
+```
+
+### 🎯 설계 패턴
+- **MVVM (Model-View-ViewModel)** 패턴 적용
+- **Riverpod**을 통한 상태관리
+
+---
+
+## 🛠️ 기술 스택
+
+### Core
+- **Flutter SDK** `^3.8.1` - 크로스플랫폼 UI 프레임워크
+- **Dart** - 메인 프로그래밍 언어
+
+### 상태관리 & 아키텍처
+- **flutter_riverpod** `^2.6.1` - 상태관리 라이브러리
+- **StateNotifier** - 상태 변화 관리
+
+### UI/UX
+- **Material Design** - 구글의 디자인 시스템
+- **Cupertino Icons** `^1.0.8` - iOS 스타일 아이콘
+
+### 유틸리티
+- **intl** `^0.19.0` - 국제화 및 숫자 포맷팅
+
+### 개발도구
+- **flutter_lints** `^5.0.0` - 코드 품질 관리
+- **flutter_test** - 테스팅 프레임워크
+
+---
+
+## 🚀 개발 과정
+
+### 1단계: 프로젝트 초기화
+```bash
+flutter create applemarket_app
+cd applemarket_app
+```
+
+### 2단계: 사용 패키지
+```yaml
+dependencies:
+  flutter_riverpod: ^2.6.1  # 상태관리
+  intl: ^0.19.0             # 숫자 포맷팅
+```
+
+### 3단계: 아키텍처 설계
+- **Model**: `Product` 클래스로 상품 데이터 구조화
+- **ViewModel**: `HomeViewModel`로 비즈니스 로직 분리  
+- **View**: `MainPage`와 `ProductDetailScreen`로 UI 구현
+
+### 4단계: 핵심 기능 구현
+1. **상품 목록 화면**: ListView.builder로 동적 리스트 구현
+2. **상품 상세 화면**: 상세 정보와 판매자 정보 표시
+3. **네비게이션**: Navigator.push로 화면 전환
+4. **상태 관리**: Riverpod Provider로 전역 상태 관리
+
+### 5단계: UI/UX 최적화
+- **반응형 레이아웃**: 다양한 화면 크기 대응
+- **그림자 효과**: BoxShadow로 카드 입체감 구현
+
+---
+
+## 📸 스크린샷
+<img width="300" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-21 at 22 56 38" src="https://github.com/user-attachments/assets/3928426c-a467-4190-89e4-dd74a52ce54c" />
+<img width="300" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-21 at 22 56 40" src="https://github.com/user-attachments/assets/39cd6376-1fd8-427f-a129-dced1192ef45" />
+<img width="300" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-21 at 23 23 34" src="https://github.com/user-attachments/assets/4ef53f92-2bdd-4559-b8f7-d08de2e18be1" />
+
+### 메인 화면
+- 상품 카드 리스트 형태로 표시
+- 상품명, 위치, 가격 정보 제공
+- 채팅 수, 관심상품 수 표시
+- 상단 알림 버튼으로 사용자 인터랙션
+
+### 상품 상세 화면  
+- 풀스크린 상품 이미지
+- 판매자 프로필과 매너온도
+- 상품 제목과 상세 설명
+- 하단 가격정보와 채팅하기 버튼
+

--- a/lib/screens/detail_page.dart
+++ b/lib/screens/detail_page.dart
@@ -147,7 +147,7 @@ class ProductDetailScreen extends ConsumerWidget {
                 SizedBox(width: 30),
                 Icon(Icons.favorite_border, color: Colors.grey[600]),
 
-                SizedBox(width: 80),
+                SizedBox(width: 50),
 
                 // 가격
                 Expanded(
@@ -157,7 +157,7 @@ class ProductDetailScreen extends ConsumerWidget {
                   ),
                 ),
 
-                SizedBox(width: 40),
+                SizedBox(width: 10),
 
                 // 채팅하기 버튼
                 Expanded(

--- a/lib/screens/detail_page.dart
+++ b/lib/screens/detail_page.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import '../models/product.dart';
+
+class ProductDetailScreen extends ConsumerWidget {
+  final Product product;
+
+  const ProductDetailScreen({super.key, required this.product});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(title: Text('중고거래')),
+      body: Column(
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // 상품 이미지
+                  SizedBox(
+                    width: double.infinity,
+                    height: 300,
+                    child: Image.asset(
+                      product.imagePath,
+                      fit: BoxFit.cover,
+                      errorBuilder: (context, error, stackTrace) {
+                        return Container(
+                          decoration: BoxDecoration(color: Colors.grey[300]),
+                          child: Center(
+                            child: Icon(
+                              Icons.image,
+                              color: Colors.grey[600],
+                              size: 80,
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+
+                  // 상품 정보
+                  Padding(
+                    padding: EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        // 판매자 정보
+                        Row(
+                          children: [
+                            CircleAvatar(
+                              radius: 25,
+                              backgroundColor: Colors.deepOrange[400],
+                              child: Icon(
+                                Icons.person,
+                                color: Colors.white,
+                                size: 40,
+                              ),
+                            ),
+                            SizedBox(width: 12),
+                            Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  '미니멀하게',
+                                  style: TextStyle(
+                                    fontSize: 15,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                                Text(
+                                  '르탄시 르탄구 르탄1동',
+                                  style: TextStyle(
+                                    fontSize: 12,
+                                    color: Colors.grey[600],
+                                  ),
+                                ),
+                              ],
+                            ),
+                            Spacer(),
+                            Column(
+                              children: [
+                                Text(
+                                  '36.5°C',
+                                  style: TextStyle(
+                                    fontWeight: FontWeight.bold,
+                                    fontSize: 15,
+                                    color: Colors.teal,
+                                  ),
+                                ),
+                                SizedBox(height: 7),
+                                Text(
+                                  '매너온도',
+                                  style: TextStyle(
+                                    decoration: TextDecoration.underline,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+
+                        SizedBox(height: 10),
+                        Divider(color: Colors.grey[400], thickness: 2),
+                        SizedBox(height: 16),
+
+                        // 상품명
+                        Text(
+                          product.name,
+                          style: TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+
+                        SizedBox(height: 8),
+
+                        // 상품 설명
+                        Text(
+                          product.description.replaceAll('\\n', '\n'),
+                          style: TextStyle(
+                            fontSize: 16,
+                            height: 1.5,
+                            color: Colors.black87,
+                          ),
+                        ),
+                        SizedBox(height: 16),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+
+          // 하단 버튼 영역
+          Container(
+            padding: EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              border: Border(top: BorderSide(color: Colors.grey[300]!)),
+            ),
+            child: Row(
+              children: [
+                SizedBox(width: 30),
+                Icon(Icons.favorite_border, color: Colors.grey[600]),
+
+                SizedBox(width: 80),
+
+                // 가격
+                Expanded(
+                  child: Text(
+                    '${NumberFormat('#,###').format(product.price)}원',
+                    style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                  ),
+                ),
+
+                SizedBox(width: 40),
+
+                // 채팅하기 버튼
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: () {},
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.orange,
+                      foregroundColor: Colors.white,
+                      padding: EdgeInsets.symmetric(vertical: 10),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(5),
+                      ),
+                    ),
+                    child: Text(
+                      '채팅하기',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+                SizedBox(width: 30),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/detail_page.dart
+++ b/lib/screens/detail_page.dart
@@ -11,7 +11,9 @@ class ProductDetailScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
-      appBar: AppBar(title: Text('중고거래')),
+      appBar: AppBar(
+        title: Align(alignment: Alignment.centerLeft, child: Text('상품 상세')),
+      ),
       body: Column(
         children: [
           Expanded(


### PR DESCRIPTION
### 🚀 개요
상품 상세페이지 구현

### 🔧 변경사항
- 제공된 디자인 및 화면 구성을 최대한 동일하게 구성
- 메인화면에서 전달받은 데이터로 판매자, 주소, 아이템, 글내용, 가격 등을 화면에 표시
- 하단 가격표시 레이아웃을 제외하고 전체화면은 SingleChildScrollView를 사용하여 스크롤
- 상단 < 버튼을 누르면 Navigator.pop을 사용하여 메인 화면으로 돌아감

### 실행 화면
<img src="https://github.com/user-attachments/assets/05aba174-cf8b-4eaf-9d01-d46c51e37614" width="300" height="600"/>


### 💡issue : #2 